### PR TITLE
Use trino-cluster for metrics label

### DIFF
--- a/src/gauges.go
+++ b/src/gauges.go
@@ -2,90 +2,92 @@ package main
 
 import "github.com/prometheus/client_golang/prometheus"
 
+var metricClusterKey = "trino-cluster"
+
 var abandonedQueries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "queries_abandoned_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var cancelledQueries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "queries_cancelled_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var completedQueries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "queries_completed_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var failedQueries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "queries_failed_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var queuedQueries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "queries_queued_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var runningQueries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "queries_running_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var inputBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "input_bytes_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var inputRows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "input_rows_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var cpuTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "cpu_time_seconds_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var execTimeAvg = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "execution_time_milliseconds_average",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var execTimeP95 = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "execution_time_milliseconds_p95",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var queuedTimeAvg = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "queued_time_milliseconds_average",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var queuedTimeP95 = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "queued_time_milliseconds_p95",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var externalFailures = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "failures_external_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var internalFailures = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "failures_internal_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var userFailures = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "failures_user_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var resourceFailures = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "trino",
 	Name:      "failures_insufficient_resources_count_total",
-}, []string{"cluster"})
+}, []string{metricClusterKey})
 
 var Gauges = []*prometheus.GaugeVec{
 	abandonedQueries,
@@ -108,22 +110,22 @@ var Gauges = []*prometheus.GaugeVec{
 }
 
 func UpdateGauges(m JmxMetrics) {
-	abandonedQueries.With(prometheus.Labels{"cluster": Cluster}).Set(m.AbandonedQueriesTotalCount)
-	abandonedQueries.With(prometheus.Labels{"cluster": Cluster}).Set(m.AbandonedQueriesTotalCount)
-	cancelledQueries.With(prometheus.Labels{"cluster": Cluster}).Set(m.CancelledQueriesTotalCount)
-	completedQueries.With(prometheus.Labels{"cluster": Cluster}).Set(m.CompletedQueriesTotalCount)
-	cpuTime.With(prometheus.Labels{"cluster": Cluster}).Set(m.ConsumedCpuTimeSecsTotalCount)
-	execTimeAvg.With(prometheus.Labels{"cluster": Cluster}).Set(m.ExecutionTimeAllTimeAvg)
-	execTimeP95.With(prometheus.Labels{"cluster": Cluster}).Set(m.ExecutionTimeAllTimeP95)
-	externalFailures.With(prometheus.Labels{"cluster": Cluster}).Set(m.ExternalFailuresTotalCount)
-	failedQueries.With(prometheus.Labels{"cluster": Cluster}).Set(m.FailedQueriesTotalCount)
-	inputBytes.With(prometheus.Labels{"cluster": Cluster}).Set(m.ConsumedInputBytesTotalCount)
-	inputRows.With(prometheus.Labels{"cluster": Cluster}).Set(m.ConsumedInputRowsTotalCount)
-	internalFailures.With(prometheus.Labels{"cluster": Cluster}).Set(m.InternalFailuresTotalCount)
-	queuedQueries.With(prometheus.Labels{"cluster": Cluster}).Set(m.QueuedQueries)
-	queuedTimeAvg.With(prometheus.Labels{"cluster": Cluster}).Set(m.QueuedTimeAllTimeAvg)
-	queuedTimeP95.With(prometheus.Labels{"cluster": Cluster}).Set(m.QueuedTimeAllTimeP95)
-	resourceFailures.With(prometheus.Labels{"cluster": Cluster}).Set(m.InsufficientResourcesFailuresTotalCount)
-	runningQueries.With(prometheus.Labels{"cluster": Cluster}).Set(m.RunningQueries)
-	userFailures.With(prometheus.Labels{"cluster": Cluster}).Set(m.UserErrorFailuresTotalCount)
+	abandonedQueries.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.AbandonedQueriesTotalCount)
+	abandonedQueries.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.AbandonedQueriesTotalCount)
+	cancelledQueries.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.CancelledQueriesTotalCount)
+	completedQueries.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.CompletedQueriesTotalCount)
+	cpuTime.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.ConsumedCpuTimeSecsTotalCount)
+	execTimeAvg.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.ExecutionTimeAllTimeAvg)
+	execTimeP95.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.ExecutionTimeAllTimeP95)
+	externalFailures.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.ExternalFailuresTotalCount)
+	failedQueries.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.FailedQueriesTotalCount)
+	inputBytes.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.ConsumedInputBytesTotalCount)
+	inputRows.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.ConsumedInputRowsTotalCount)
+	internalFailures.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.InternalFailuresTotalCount)
+	queuedQueries.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.QueuedQueries)
+	queuedTimeAvg.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.QueuedTimeAllTimeAvg)
+	queuedTimeP95.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.QueuedTimeAllTimeP95)
+	resourceFailures.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.InsufficientResourcesFailuresTotalCount)
+	runningQueries.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.RunningQueries)
+	userFailures.With(prometheus.Labels{metricClusterKey: Cluster}).Set(m.UserErrorFailuresTotalCount)
 }


### PR DESCRIPTION
### Context
In order to be able to have metrics for multiple trino clusters, there is a required env-var TRINO_EXPORTER_CLUSTER, which is applied as a Prometheus metric label under the key `cluster`. That key is problematic, because it may conflict with other keys, in our case with the EKS cluster label.

### Fix
I'm changing the label key to `trino-cluster` so that it's less likely to cause conflicts. Eventually, this may be made configurable, but for now, I'm ok hard-coding it.